### PR TITLE
Added post type management

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,15 +13,14 @@ Finally, add the shortcode [compendium] to the page that you would like the reso
 - Ability to select only certain categories per post type to be displayed.
 - Include RSS feed.
 
-###Known bugs
-* After enabling or disabling post type, new post type won't appear/disappear until page refresh.
-
 ###Change log
 
 #####Version 0.8
 * Added feature to create custom post types
 * Removed enable post type feature - user can simply use a slug provided in the table and name their post type by preference
 * Fixed script loading issue
+* Set admin menu to be top-level and created subpage for post type management
+* Added a forced refresh after submitting post type form to fix issue of post types being unavailable[*available*] after creation[*deletion*].
 
 #####Version 0.7
 * Added ability to create common post types supported by plugin

--- a/compendium-resources.php
+++ b/compendium-resources.php
@@ -517,7 +517,7 @@ class Compendium_Resources
                 return array(
                     'name'=> 'Brochure',
                     'plural' => 'Brochures',
-                    'dashicons' => 'data:image/svg+xml;base64,' . base64_encode( '<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="20px" height="20px" viewBox="0 0 100 100"><path fill="black" d="M34.9 95l-30-21.4V5l30 21.4L64.9 5l30 21.4V95l-30-21.4zM34.9 26.4V95M64.9 73.6V5.1"></path></svg>' ),
+                    'dashicons' => 'dashicons-admin-post',
                     'icon' => '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" enable-background="new 0 0 100 100"><style type="text/css">.st0{fill:none;stroke:#000;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;}</style><path class="st0 line" d="M34.9 95l-30-21.4V5l30 21.4L64.9 5l30 21.4V95l-30-21.4zM34.9 26.4V95M64.9 73.6V5.1"/></svg>'
                 );
 
@@ -597,13 +597,6 @@ class Compendium_Resources
                     'plural' => 'Items',
                     'dashicons' => 'dashicons-admin-post',
                     'icon' => '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" enable-background="new 0 0 100 100"><style type="text/css">.st0{fill:none;stroke:#000;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;} .st1{fill:none;stroke:#000;stroke-width:2;stroke-linejoin:round;stroke-miterlimit:10;}</style><path class="st0 line" d="M81.3 12.8v47H18.7v-47zM10.9 67.6V10.9c0-3.2 2.6-5.9 5.9-5.9h66.5c3.2 0 5.9 2.6 5.9 5.9v56.7"/><path class="st0 line" d="M57.8 67.6v3.9H42.2v-3.9H6.9v7.8c0 2.2 1.8 3.9 3.9 3.9H89c2.2 0 3.9-1.8 3.9-3.9v-7.8H57.8zM7 95h85.9M50 95V79.3"/><circle class="st0 line" cx="63.7" cy="26.5" r="5.9"/><circle class="st0 line" cx="63.7" cy="46.1" r="5.9"/><circle class="st0 line" cx="36.3" cy="36.3" r="5.9"/><path class="st1 line" d="M41.6 33.8L58 27.3M41.6 38.8L58 45.3"/></svg>'
-                );
-            case 'managed':
-                return array(
-                    'name'=> 'Managed',
-                    'plural' => 'Managed',
-                    'dashicons' => 'dashicons-edit',
-                    'icon' => '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" enable-background="new 0 0 100 100"><style type="text/css">.st0{fill:none;stroke:#000;stroke-width:3;stroke-linejoin:round;stroke-miterlimit:10;} .st1{fill:none;stroke:#000;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;} .st4{fill:none;stroke:#000;stroke-width:3;stroke-miterlimit:10;}</style><path class="st0 line" d="M49 91.3H4.5v-89h46.6l21.2 21.2v36"/><path class="st1 line" d="M51.1 2.3v21.2h21.2"/><path class="st4 line" d="M62.81 79.39l15.98-15.98 10.747 10.748-15.98 15.98zM58.4 84.8l-3.1 10.8c-.2.6 0 1.2.4 1.6.3.3.7.5 1.2.5.2 0 .3 0 .5-.1l10.8-3.1-9.8-9.7zM95.1 66.3l-8.4-8.4c-.7-.7-1.7-.7-2.4 0l-5.5 5.5 10.8 10.8 5.5-5.5c.6-.7.6-1.7 0-2.4zM19.4 35.4l6.3 6.3 10.5-10.5M40.7 39.7h21M40.7 56.7h21M19.4 52.5l6.3 6.3 10.5-10.5"/></svg>'
                 );
             case 'mms':
                 return array(

--- a/css/admin-styles.css
+++ b/css/admin-styles.css
@@ -30,10 +30,6 @@ input[name="compendium-title"] {
     width:100%;
 }
 .svg-list tr td:first-child {
-    width:15%;
-    padding-left:10px;
-}
-.svg-list tr td:nth-child(2) {
     width:30%;
 }
 .svg-list tr:nth-child(even) {
@@ -74,6 +70,9 @@ svg {
 }
 .custom-types .custom-new{
     background:#ccc;
+}
+.custom-types td:first-child {
+    padding: 5px 10px;
 }
 .custom-types .custom-type-delete {
     background: red;


### PR DESCRIPTION
Plugin settings set to top-level in admin menu, and post type management moved to submenu beneath that.  I removed the "enable post type" functionality because it felt excessive along with the ability to create a custom type.  The icon table has been reformatted to inform users of the icons that will be displayed in the resource center according to post slug.